### PR TITLE
pass the server to ServerTree.remove

### DIFF
--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -37,7 +37,6 @@ Volume {
 				server.sync;
 
 				updateFunc = {
-					thisMethod.postln;
 					ampSynth = nil;
 					if(persist) { this.updateSynth }
 				};

--- a/SCClassLibrary/Common/Control/Volume.sc
+++ b/SCClassLibrary/Common/Control/Volume.sc
@@ -91,7 +91,7 @@ Volume {
 	}
 
 	freeSynth {
-		ServerTree.remove(updateFunc);
+		ServerTree.remove(updateFunc, server);
 		updateFunc = nil;
 		ampSynth.release;
 		ampSynth = nil


### PR DESCRIPTION
The server needs to be passed to `ServerTree.remove`, otherwise Volume's `updateFunc` doesn't get removed.