### PR TITLE
classlib: properly deprecate Server.userSpecifiedClientID

### DIFF
--- a/HelpSource/Classes/Server.schelp
+++ b/HelpSource/Classes/Server.schelp
@@ -369,6 +369,9 @@ code::true:: if the server is running on the same machine as sclang, code::false
 method:: remoteControlled
 code::true:: if the server is not being controlled by the machine on which it is running, code::false:: otherwise. This value is the same as code::isLocal:: unless explicitly set.
 
+method:: userSpecifiedClientID
+Deprecated in 3.9. Returns code::false::. Server:clientID can now be set while a server is off, and is locked while the server is running. Thus, userSpecifiedClientID is no longer needed internally, and meaningless.
+
 subsection:: Message Bundling
 
 Server provides support for automatically bundling messages. This is quite convenient in object style, and ensures synchronous execution. See also link::Guides/Bundled-Messages::

--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -378,12 +378,6 @@ Server {
 
 	/* clientID */
 
-	userSpecifiedClientID {
-		this.deprecated(thisMethod);
-		"Server:clientID can now be set while a server is off, and is locked while the server is running. Thus, userSpecifiedClientID is no longer needed internally, and meaningless. Returns false just in case user code calls this.".postln;
-		^false
-	}
-
 	// clientID is settable while server is off, and locked while server is running
 	// called from prHandleClientLoginInfoFromServer once after booting.
 	clientID_ { |val|

--- a/SCClassLibrary/deprecated/3.9/deprecated-3.9.sc
+++ b/SCClassLibrary/deprecated/3.9/deprecated-3.9.sc
@@ -96,3 +96,10 @@ SharedIn : AbstractIn {
 		}
 	}
 }
+
++ Server {
+	userSpecifiedClientID {
+		this.deprecated(thisMethod);
+		^false
+	}
+}


### PR DESCRIPTION
 also add documentation with explanation.