### PR TITLE
fix Server boot behavior w/ GUIs, add tests for Server + GUI behavior

### DIFF
--- a/SCClassLibrary/Common/Control/Server.sc
+++ b/SCClassLibrary/Common/Control/Server.sc
@@ -367,13 +367,13 @@ Server {
 	}
 
 	initTree {
-		forkIfNeeded {
+		fork({
 			this.sendDefaultGroups;
 			tree.value(this);
 			this.sync;
 			ServerTree.run(this);
 			this.sync;
-		};
+		}, AppClock);
 	}
 
 	/* clientID */

--- a/SCClassLibrary/Common/Control/ServerStatus.sc
+++ b/SCClassLibrary/Common/Control/ServerStatus.sc
@@ -253,13 +253,13 @@ ServerStatusWatcher {
 				if(addingStatusWatcher) {
 					// this needs to be forked so that ServerBoot and ServerTree will definitely run before
 					// notified is true.
-					forkIfNeeded {
+					fork({
 						this.prFinalizeBoot;
 
 						// serverRunning will now return true, and serverBooting will be marked as false
 						notified = true;
-						{ server.changed(\serverRunning) }.defer;
-					};
+						server.changed(\serverRunning);
+					}, AppClock);
 				} {
 					notified = true;
 				}

--- a/testsuite/classlibrary/TestServer_GUI.sc
+++ b/testsuite/classlibrary/TestServer_GUI.sc
@@ -1,0 +1,105 @@
+// TestServer_GUI.sc
+// Author: Brian Heim (brianlheim@gmail.com)
+// Tests for GUI behavior during ServerBoot, ServerTree, ServerQuit
+TestServer_GUI : UnitTest {
+
+	var window, button;
+
+	setUp {
+		window = Window.new;
+		button = Button(window);
+		button.states_([["a"], ["b"]]);
+		button.value_(0);
+	}
+
+	tearDown {
+		window.close;
+		window = button = nil;
+	}
+
+	// Since we have no programmatic way to tell when ServerBoot/ServerTree have finished,
+	// we wait on a timeout.
+
+	// Test that a GUI function executed by ServerBoot completes.
+	// In other words, tests that ServerBoot functions run on an AppClock.
+	test_serverBoot {
+		var updateFunc;
+		var server = Server.default;
+		var cond = Condition();
+
+		updateFunc = { button.value_(1); cond.test_(true).signal };
+		ServerBoot.add(updateFunc, server);
+		this.bootServer(server);
+
+		fork { 3.wait; cond.test_(true).signal };
+		cond.wait;
+
+		this.assert(button.value == 1, "ServerBoot should be able to update GUI objects in the main function");
+
+		ServerBoot.remove(updateFunc, server);
+		server.quit;
+	}
+
+	// Test that a GUI function executed by ServerTree completes during boot.
+	// Simulates behavior of FreqScope, etc.
+	test_serverTreeDuringBoot {
+		var updateFunc;
+		var server = Server.default;
+		var cond = Condition();
+
+		updateFunc = { button.value_(1); cond.test_(true).signal };
+		ServerTree.add(updateFunc, server);
+		this.bootServer(server);
+
+		fork { 3.wait; cond.test_(true).signal };
+		cond.wait;
+
+		this.assert(button.value == 1, "ServerTree should be able to update GUI objects in the main function during boot");
+
+		ServerTree.remove(updateFunc, server);
+		server.quit;
+	}
+
+	// Test that a GUI function executed by ServerTree completes during cmd-period.
+	// Simulates behavior of FreqScope, etc.
+	test_serverTreeDuringCmdPeriod {
+		var updateFunc;
+		var server = Server.default;
+		var cond = Condition();
+
+		this.bootServer(server);
+
+		updateFunc = { button.value_(1); cond.test_(true).signal };
+		ServerTree.add(updateFunc, server);
+
+		CmdPeriod.run;
+
+		fork { 3.wait; cond.test_(true).signal };
+		cond.wait;
+
+		this.assert(button.value == 1, "ServerTree should be able to update GUI objects in the main function during CmdPeriod");
+
+		ServerTree.remove(updateFunc, server);
+		server.quit;
+	}
+
+	// Test that a GUI function executed by ServerQuit completes.
+	test_serverQuit {
+		var updateFunc;
+		var server = Server.default;
+		var cond = Condition();
+
+		updateFunc = { button.value_(1); cond.test_(true).signal };
+		ServerQuit.add(updateFunc, server);
+
+		this.bootServer(server);
+		server.quit;
+
+		fork { 3.wait; cond.test_(true).signal };
+		cond.wait;
+
+		this.assert(button.value == 1, "ServerQuit should be able to update GUI objects in the main function");
+
+		ServerQuit.remove(updateFunc, server);
+	}
+}

--- a/testsuite/classlibrary/TestServer_ServerGUI.sc
+++ b/testsuite/classlibrary/TestServer_ServerGUI.sc
@@ -1,0 +1,140 @@
+// TestServer_ServerGUI.sc
+// Author: Brian Heim (brianlheim@gmail.com)
+// Tests for the GUI created by s.makeGui
+// TODO: recording state tests?
+TestServer_ServerGUI : UnitTest {
+
+	// Note: If you are changing these, you probably mean to change `getButtons`!
+	const bootButtonIdx = 0;
+	const killButtonIdx = 1;
+	const defaultButtonIdx = 2;
+	const recordButtonIdx = 3;
+	const volumeButtonIdx = 4;
+
+	var server;
+	var window;
+	var buttons;
+	var buttonNames;
+
+	setUp {
+		if(buttonNames.isNil) {
+			buttonNames = Array.fill(5, "");
+			buttonNames[bootButtonIdx] = "boot";
+			buttonNames[killButtonIdx] = "kill";
+			buttonNames[defaultButtonIdx] = "default";
+			buttonNames[recordButtonIdx] = "record";
+			buttonNames[volumeButtonIdx] = "volume";
+		};
+
+		server = Server.default;
+		server.makeGui;
+		window = server.window;
+		buttons = this.getButtons(window);
+	}
+
+	tearDown {
+		window.close;
+		0.5.wait; // XXX: wait for window to execute its onClose
+		window = buttons = server = nil;
+	}
+
+	// Puts the buttons from the window in the same order as the indices expected
+	// by this class. If the order ever changes, it would be much easier to adjust
+	// here than to edit the values in each test method.
+	getButtons { |w|
+		^w.view.children.select(_.isKindOf(QButton));
+	}
+
+	// Asserts states (values & enabled/disabled) of buttons. `testName` is the
+	// name of the condition being tested (e.g. "Before booting")
+	assertButtonStates { |expValues, expEnabled, testName|
+		var actValues = buttons.collect(_.value);
+		var actEnabled = buttons.collect(_.enabled);
+
+		expValues.do { |val, i|
+			this.assertEquals(actValues[i], expValues[i],
+				"%: '%' button should have correct value".format(testName, buttonNames[i]));
+			this.assert(actEnabled[i] == expEnabled[i],
+				"%: '%' button should be %".format(
+					testName, buttonNames[i], expEnabled[i].if("enabled", "disabled")));
+		}
+	}
+
+	// test the GUI state without any action taken
+	test_noBoot {
+		var expValues = [0, 0, 1, 0, 0];
+		var expEnabled = [true, true, true, false, true];
+		this.assertButtonStates(expValues, expEnabled, "Before booting");
+	}
+
+	// GUI state after booting
+	test_boot {
+		var expValues = [1, 0, 1, 0, 0];
+		var expEnabled = [true, true, true, true, true];
+		this.bootServer(server);
+		this.assertButtonStates(expValues, expEnabled, "After booting");
+		server.quit;
+	}
+
+	// GUI state after booting and muting the server
+	test_mute {
+		var expValues = [1, 0, 1, 0, 1];
+		var expEnabled = [true, true, true, true, true];
+		this.bootServer(server);
+		server.volume.mute;
+		this.assertButtonStates(expValues, expEnabled, "After muting");
+		server.volume.unmute;
+		server.quit;
+	}
+
+	// GUI state after booting, muting, then unmuting the server
+	test_unmute {
+		var expValues = [1, 0, 1, 0, 0];
+		var expEnabled = [true, true, true, true, true];
+		this.bootServer(server);
+		server.volume.mute;
+		server.volume.unmute;
+		this.assertButtonStates(expValues, expEnabled, "After muting and unmuting");
+		server.quit;
+	}
+
+	// GUI state after booting then quitting
+	test_quit {
+		var expValues = [0, 0, 1, 0, 0];
+		var expEnabled = [true, true, true, false, true];
+		this.bootServer(server);
+		server.quit;
+		this.assertButtonStates(expValues, expEnabled, "After quitting");
+	}
+
+	// GUI state after setting not default
+	test_undefault {
+		var expValues = [0, 0, 0, 0, 0];
+		var expEnabled = [true, true, true, false, true];
+		var oldDefault, testServer;
+
+		oldDefault = Server.default;
+		Server.default = testServer = Server(thisMethod.name);
+
+		this.assertButtonStates(expValues, expEnabled, "After un-defaulting this server");
+
+		testServer.remove;
+		Server.default = oldDefault;
+	}
+
+	// GUI state after setting not default, then setting default again
+	test_redefault {
+		var expValues = [0, 0, 1, 0, 0];
+		var expEnabled = [true, true, true, false, true];
+		var oldDefault, testServer;
+
+		oldDefault = Server.default;
+		Server.default = testServer = Server(thisMethod.name);
+
+		testServer.remove;
+		Server.default = oldDefault;
+
+		this.assertButtonStates(expValues, expEnabled, "After re-defaulting this server");
+	}
+
+}


### PR DESCRIPTION
- TestServer_GUI tests that GUI actions taken during ServerBoot,
ServerTree, and ServerQuit do not need to be separately deferred in
order to complete successfully.
- TestServer_ServerGUI tests the behavior of the GUI created by
s.makeGui, and is a more hands-on approach to that taken in
TestServer_GUI.