### PR TITLE
Avoid using default server in test suite

### DIFF
--- a/testsuite/classlibrary/TestServer_GUI.sc
+++ b/testsuite/classlibrary/TestServer_GUI.sc
@@ -3,18 +3,22 @@
 // Tests for GUI behavior during ServerBoot, ServerTree, ServerQuit
 TestServer_GUI : UnitTest {
 
-	var window, button;
+	var window, button, server;
 
 	setUp {
 		window = Window.new;
 		button = Button(window);
 		button.states_([["a"], ["b"]]);
 		button.value_(0);
+
+		server = Server(this.class.name);
 	}
 
 	tearDown {
+		server.remove;
+
 		window.close;
-		window = button = nil;
+		window = button = server = nil;
 	}
 
 	// Since we have no programmatic way to tell when ServerBoot/ServerTree have finished,
@@ -24,7 +28,6 @@ TestServer_GUI : UnitTest {
 	// In other words, tests that ServerBoot functions run on an AppClock.
 	test_serverBoot {
 		var updateFunc;
-		var server = Server.default;
 		var cond = Condition();
 
 		updateFunc = { button.value_(1); cond.test_(true).signal };
@@ -44,7 +47,6 @@ TestServer_GUI : UnitTest {
 	// Simulates behavior of FreqScope, etc.
 	test_serverTreeDuringBoot {
 		var updateFunc;
-		var server = Server.default;
 		var cond = Condition();
 
 		updateFunc = { button.value_(1); cond.test_(true).signal };
@@ -64,7 +66,6 @@ TestServer_GUI : UnitTest {
 	// Simulates behavior of FreqScope, etc.
 	test_serverTreeDuringCmdPeriod {
 		var updateFunc;
-		var server = Server.default;
 		var cond = Condition();
 
 		this.bootServer(server);
@@ -86,13 +87,12 @@ TestServer_GUI : UnitTest {
 	// Test that a GUI function executed by ServerQuit completes.
 	test_serverQuit {
 		var updateFunc;
-		var server = Server.default;
 		var cond = Condition();
 
 		updateFunc = { button.value_(1); cond.test_(true).signal };
 		ServerQuit.add(updateFunc, server);
 
-		this.bootServer(server);
+		server.bootSync;
 		server.quit;
 
 		fork { 3.wait; cond.test_(true).signal };

--- a/testsuite/classlibrary/TestVolume.sc
+++ b/testsuite/classlibrary/TestVolume.sc
@@ -1,7 +1,7 @@
 TestVolume : UnitTest {
 
 	test_booting {
-		var s = Server.default;
+		var s = Server(thisMethod.name);
 		var correctReply = [ '/g_queryTree.reply', 0, 0, 2, 1, 0, 1000, -1, 'volumeAmpControl2' ];
 		var queryReply;
 		var nodeIDidx = 6;
@@ -26,15 +26,15 @@ TestVolume : UnitTest {
 			"Server boot should send volume synthdef and create synth immediately when set to nonzero volume.");
 
 		s.volume.reset;
-		s.quit;
+		s.quit.remove;
 	}
 
 	test_setVolume {
 
 		var s, ampSynthVolume;
-		s = Server.default;
+		s = Server(thisMethod.name);
 
-		this.bootServer;
+		this.bootServer(s);
 		s.sync;
 
 		this.assert(s.volume.volume == 0, "initial volume is 0 db");
@@ -47,24 +47,22 @@ TestVolume : UnitTest {
 		this.assertFloatEquals(ampSynthVolume, s.volume.volume.dbamp, "volume level correctly set", 0.0001);
 
 		s.volume.reset;
-		s.quit;
+		s.quit.remove;
 	}
 
 	test_numOutputs {
 
 		var s, default_numChannels;
-		s = Server.default;
-		default_numChannels = s.options.numOutputBusChannels;
+		s = Server(thisMethod.name);
 
 		s.options.numOutputBusChannels = 8;
 
-		this.bootServer;
+		this.bootServer(s);
 		s.sync;
 
 		this.assert(s.outputBus.numChannels == s.volume.numOutputChannels, "volume synth has correct number of channels");
 
-		s.quit;
-		s.options.numOutputBusChannels = default_numChannels;
+		s.quit.remove;
 	}
 
 }


### PR DESCRIPTION
As pointed out by @snappizz, these test suites should not be using the default server wherever possible.

Some small tweaks to make the tests works.

Also refactored TestServer_GUI